### PR TITLE
Fix Crash After Connection Failure

### DIFF
--- a/app/src/main/java/ejunkins/rovercontroller/MainActivity.java
+++ b/app/src/main/java/ejunkins/rovercontroller/MainActivity.java
@@ -1,11 +1,9 @@
 package ejunkins.rovercontroller;
 
-
+import android.app.AlertDialog;
 import android.bluetooth.BluetoothAdapter;
 import android.bluetooth.BluetoothDevice;
-import android.bluetooth.BluetoothServerSocket;
 import android.bluetooth.BluetoothSocket;
-import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -28,15 +26,19 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
+import ejunkins.rovercontroller.utils.AlertDialogHelper;
+
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
 
 //import com.cardiomood.android.controls.gauge.SpeedometerGauge;
 
-public class MainActivity extends AppCompatActivity implements AdapterView.OnItemSelectedListener, ControlStick.JoystickListener, RightControlStick.JoystickListener, View.OnClickListener{
-    private Context mContext;
-    private ControlStick mControlStick;
-    private RightControlStick mRightControlStick;
+public class MainActivity extends AppCompatActivity
+        implements AdapterView.OnItemSelectedListener, ControlStick.JoystickListener,
+        RightControlStick.JoystickListener, View.OnClickListener {
+
+    private static final String TAG = "MainActivity";
+
     private Vibrator mVibrator; // For Haptic Feedback
 
     StringBuffer mThrottle;
@@ -48,27 +50,25 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
     CheckBox mConnected;
 
     BluetoothSocket mSocket;
-    BluetoothServerSocket mServerSocket;
     BluetoothDevice mBluetoothDevice = null;
-    BluetoothAdapter mBluetoothAdapter;
     Button mSocketButton;
     Button mDisconnectButton;
     String mConnectionName;
     ToggleButton mToggleButton;
-    ToggleButton mServoButton;
     Handler mConnectionStatusHandler;
     SocketRunnable socketrunnable;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                WindowManager.LayoutParams.FLAG_FULLSCREEN);
         requestWindowFeature(Window.FEATURE_NO_TITLE);
-        this.getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        requestWindowFeature(Window.FEATURE_NO_TITLE);
-        mContext = getApplicationContext();
-        mControlStick = new ControlStick(this);
-        mRightControlStick = new RightControlStick(this);
         setContentView(R.layout.activity_main);
+
+        // FIXME: ControlStick should use a setter for the listener instead of using Context
+        ControlStick controlStick = new ControlStick(this);
+        RightControlStick rightControlStick = new RightControlStick(this);
 
         mThrottle = new StringBuffer();
         mSteering = new StringBuffer();
@@ -85,22 +85,23 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
         mServo.append(0);
         mExit.append("False");
         mConnectionStatusHandler = new Handler();
-        mConnected = (CheckBox) findViewById(R.id.checkBox);
-        mSocketButton = (Button) findViewById(R.id.socketConnect);
-        mDisconnectButton = (Button) findViewById(R.id.disconnect);
-        mToggleButton = (ToggleButton) findViewById(R.id.toggleButton);
+        mConnected = (CheckBox)findViewById(R.id.checkBox);
+        mSocketButton = (Button)findViewById(R.id.socketConnect);
+        mDisconnectButton = (Button)findViewById(R.id.disconnect);
+        mToggleButton = (ToggleButton)findViewById(R.id.toggleButton);
 
-        mVibrator = (Vibrator) this.getSystemService(VIBRATOR_SERVICE); //For Haptic Feedback
+        mVibrator = (Vibrator)this.getSystemService(VIBRATOR_SERVICE); //For Haptic Feedback
         mSocketButton.setOnClickListener(this);
         mDisconnectButton.setOnClickListener(this);
-        socketrunnable = new SocketRunnable(mThrottle, mSteering, mRoverFace, mServo, mSocket, mExit,
-                mConnectedStatus);
 
-
+        socketrunnable =
+                new SocketRunnable(mThrottle, mSteering, mRoverFace, mServo, mSocket, mExit,
+                        mConnectedStatus);
 
         Spinner dropdown = (Spinner)findViewById(R.id.spinner1);
-        String[] items = new String[]{"None","8Bit", "Wink", "Happy"};
-        ArrayAdapter<String> adapter = new ArrayAdapter<String>(this, android.R.layout.simple_spinner_dropdown_item, items);
+        String[] items = new String[] {"None", "8Bit", "Wink", "Happy"};
+        ArrayAdapter<String> adapter =
+                new ArrayAdapter<>(this, android.R.layout.simple_spinner_dropdown_item, items);
         dropdown.setAdapter(adapter);
         dropdown.setOnItemSelectedListener(this);
 
@@ -115,22 +116,18 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
 
     public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
 
-        Spinner spinner = (Spinner) parent;
-        if(spinner.getId() == R.id.spinner1)
-        {
+        Spinner spinner = (Spinner)parent;
+        if (spinner.getId() == R.id.spinner1) {
             switch (pos) {
                 case 0:
-                    // Whatever you want to happen when the first item gets selected
                     mRoverFace.delete(0, mRoverFace.length());
                     mRoverFace.append(0);
                     break;
                 case 1:
-                    // Whatever you want to happen when the second item gets selected
                     mRoverFace.delete(0, mRoverFace.length());
                     mRoverFace.append(1);
                     break;
                 case 2:
-                    // Whatever you want to happen when the thrid item gets selected
                     mRoverFace.delete(0, mRoverFace.length());
                     mRoverFace.append(2);
                     break;
@@ -138,10 +135,7 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
                     mRoverFace.delete(0, mRoverFace.length());
                     mRoverFace.append(3);
             }
-        }
-
-        else
-        {
+        } else {
             /*
             switch (pos) {
                 case 0:
@@ -152,7 +146,6 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
             }
             */
         }
-
     }
 
     public void onNothingSelected(AdapterView<?> parent) {
@@ -161,25 +154,23 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
 
     @Override
     public void onJoystickMoved(float xPercent, float yPercent, int source) {
-        switch (source)
-        {
+        switch (source) {
             case R.id.JoystickRight:
                 mSteering.delete(0, mSteering.length());
-                mSteering.append((int) (xPercent * 100));
-                mVibrator.vibrate((int) Math.abs((100* xPercent)/3));
+                mSteering.append((int)(xPercent * 100));
+                mVibrator.vibrate((int)Math.abs((100 * xPercent) / 3));
                 break;
 
             case R.id.JoystickLeft:
                 mThrottle.delete(0, mThrottle.length());
-                if (!mToggleButton.isChecked()){
-                    yPercent = yPercent/2;
+                if (!mToggleButton.isChecked()) {
+                    yPercent = yPercent / 2;
                     mToggleButton.setBackgroundResource(R.drawable.button_bg_round_red);
-                }
-                else{
+                } else {
                     mToggleButton.setBackgroundResource(R.drawable.button_bg_round);
                 }
-                mThrottle.append((int) (yPercent * -100));
-                mVibrator.vibrate((int) Math.abs((100* yPercent)/3));
+                mThrottle.append((int)(yPercent * -100));
+                mVibrator.vibrate((int)Math.abs((100 * yPercent) / 3));
                 break;
         }
     }
@@ -187,77 +178,116 @@ public class MainActivity extends AppCompatActivity implements AdapterView.OnIte
     @RequiresApi(api = Build.VERSION_CODES.KITKAT)
     @Override
     public void onClick(View v) {
-        mConnectionName = "demoRover";
-        final BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
-        Set<BluetoothDevice> pairedDevices = mBluetoothAdapter.getBondedDevices();
-        if (pairedDevices.size() > 0) {
-            for (BluetoothDevice device : pairedDevices) {
-                if (Objects.equals(device.getName(), mConnectionName)) {
-                    mBluetoothDevice = device;
-                }
+        if (connectRover()) {
+            switch (v.getId()) {
+                case R.id.socketConnect:
+                    subscribeToRover();
+                    break;
+                case R.id.disconnect:
+                    unsubscribeFromRover();
+                    break;
             }
         }
-        BluetoothSocket tmp = null;
-        String uuid = "94f39d29-7d6d-437d-973b-fba39e49d4ee";
-        try {
-            tmp = mBluetoothDevice.createRfcommSocketToServiceRecord(UUID.fromString(uuid));
-        } catch (IOException e) {
-            Log.e("connectfail", "Socket's create() method failed", e);
-        }
-        mSocket = tmp;
-        mBluetoothAdapter.cancelDiscovery();
-        try {
-            mSocket.connect();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        switch (v.getId()){
-            case R.id.socketConnect:
-                mExit.delete(0, mExit.length());
-                mExit.append("False");
-                SocketRunnable socketrunnable = new SocketRunnable(mThrottle, mSteering, mRoverFace,
-                        mServo,
-                        mSocket, mExit, mConnectedStatus);
-                new Thread(socketrunnable).start();
-
-                break;
-            case R.id.disconnect:
-                mExit.delete(0, mExit.length());
-                mExit.append("True");
-                break;
-        }
-
     }
+
     @Override
     public void onPause() {
         super.onPause();
-        mExit.delete(0, mExit.length());
-        mExit.append("True");
+        unsubscribeFromRover();
     }
+
     @Override
     public void onStart() {
         super.onStart();
-        mConnectionStatusHandler.postDelayed(new Runnable(){
-            public void run(){
-                Log.d("mConnectionStatusHandler", mConnectedStatus.toString());
-                if (mConnectedStatus.toString().equals("49")){
-                    mConnected.setChecked(TRUE);
-                    mDisconnectButton.setBackgroundResource(R.drawable.disconnect_button_red);
-                    mSocketButton.setBackgroundResource(R.drawable.rounded_button_grey);
-                } else if (mConnectedStatus.toString().equals("48")) {
-                    mExit.delete(0, mExit.length());
-                    mExit.append("True");
-                    mConnected.setChecked(FALSE);
-                    mSocketButton.setBackgroundResource(R.drawable.rounded_button);
-                    mDisconnectButton.setBackgroundResource(R.drawable.rounded_button_grey);
-                } else {
-                    mConnected.setChecked(FALSE);
-                    mSocketButton.setBackgroundResource(R.drawable.rounded_button);
-                    mDisconnectButton.setBackgroundResource(R.drawable.rounded_button_grey);
+        mConnectionStatusHandler.postDelayed(new Runnable() {
+            public void run() {
+                Log.d(TAG, "ConnectionStatus = [" + mConnectedStatus.toString() + "]");
+                switch (mConnectedStatus.toString()) {
+                    case "49":
+                        mConnected.setChecked(TRUE);
+                        mDisconnectButton.setBackgroundResource(R.drawable.disconnect_button_red);
+                        mSocketButton.setBackgroundResource(R.drawable.rounded_button_grey);
+                        break;
+                    case "48":
+                        unsubscribeFromRover();
+                        mConnected.setChecked(FALSE);
+                        mSocketButton.setBackgroundResource(R.drawable.rounded_button);
+                        mDisconnectButton.setBackgroundResource(R.drawable.rounded_button_grey);
+                        break;
+                    default:
+                        mConnected.setChecked(FALSE);
+                        mSocketButton.setBackgroundResource(R.drawable.rounded_button);
+                        mDisconnectButton.setBackgroundResource(R.drawable.rounded_button_grey);
+                        break;
                 }
                 mConnectionStatusHandler.postDelayed(this, 1000);
             }
         }, 1000);
+    }
+
+    /**
+     * Attempts to create and open a bluetooth socket with the Rover
+     * <p>
+     * Should this operation fail an appropriate alert dialog will be displayed to the user.
+     *
+     * @return {@code true} if the socket is successfully create, {@code false} otherwise.
+     */
+    private boolean connectRover() {
+        mConnectionName = "demoRover";
+        final BluetoothAdapter bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+
+        if (bluetoothAdapter != null) {
+            Set<BluetoothDevice> pairedDevices = bluetoothAdapter.getBondedDevices();
+            if (!pairedDevices.isEmpty()) {
+                for (BluetoothDevice device : pairedDevices) {
+                    if (Objects.equals(device.getName(), mConnectionName)) {
+                        mBluetoothDevice = device;
+                    }
+                }
+
+                if (mBluetoothDevice != null) {
+                    BluetoothSocket tmpSocket;
+                    String uuid = "94f39d29-7d6d-437d-973b-fba39e49d4ee";
+                    try {
+                        tmpSocket = mBluetoothDevice
+                                .createRfcommSocketToServiceRecord(UUID.fromString(uuid));
+
+                        mSocket = tmpSocket;
+                        bluetoothAdapter.cancelDiscovery();
+                        mSocket.connect();
+
+                        return true;
+                    } catch (IOException e) {
+                        Log.e(TAG, "onClick: Failed to establish socket.", e);
+                        showConnectionError(R.string.alert_message_bluetooth_connection_error);
+                    }
+                } else {
+                    showConnectionError(R.string.alert_message_bluetooth_device_not_found);
+                }
+            } else {
+                showConnectionError(R.string.alert_message_bluetooth_device_not_found);
+            }
+        } else {
+            showConnectionError(R.string.alert_message_bluetooth_not_supported);
+        }
+        return false;
+    }
+
+    private void subscribeToRover() {
+        mExit.delete(0, mExit.length());
+        mExit.append("False");
+        SocketRunnable socketrunnable =
+                new SocketRunnable(mThrottle, mSteering, mRoverFace, mServo, mSocket, mExit,
+                        mConnectedStatus);
+        new Thread(socketrunnable).start();
+    }
+
+    private void unsubscribeFromRover() {
+        mExit.delete(0, mExit.length());
+        mExit.append("True");
+    }
+
+    private AlertDialog showConnectionError(int messageId) {
+        return AlertDialogHelper.showConnectionErrorDialog(this, messageId);
     }
 }

--- a/app/src/main/java/ejunkins/rovercontroller/utils/AlertDialogHelper.java
+++ b/app/src/main/java/ejunkins/rovercontroller/utils/AlertDialogHelper.java
@@ -1,0 +1,17 @@
+package ejunkins.rovercontroller.utils;
+
+import android.app.AlertDialog;
+import android.content.Context;
+
+import ejunkins.rovercontroller.R;
+
+public class AlertDialogHelper {
+
+    public static AlertDialog showConnectionErrorDialog(Context context, int resId) {
+        return new AlertDialog.Builder(context)
+                .setTitle(R.string.alert_title_connection_error)
+                .setMessage(resId)
+                .setNeutralButton(android.R.string.ok, null)
+                .show();
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,9 @@
     <string name="normal">Normal</string>
     <string name="connect">Connect</string>
     <string name="disconnect">Disconnect</string>
+
+    <string name="alert_title_connection_error">Connection Error</string>
+    <string name="alert_message_bluetooth_not_supported">Bluetooth is not supported on your device.</string>
+    <string name="alert_message_bluetooth_device_not_found">Unable to locate rover.</string>
+    <string name="alert_message_bluetooth_connection_error">Error creating connection with rover</string>
 </resources>


### PR DESCRIPTION
Added proper error handling around the socket creation and connecting.

Added alert dialog helper class in `utils` package.

Fixed misc. code style issues within `MainActivity` to improve
readability

Relevant crash logs from an emulator running Android 7.1.1

```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.util.Set android.bluetooth.BluetoothAdapter.getBondedDevices()' on a null object reference
        at ejunkins.rovercontroller.MainActivity.onClick(MainActivity.java:192)
        at android.view.View.performClick(View.java:5637)
        at android.view.View$PerformClick.run(View.java:22429)
        at android.os.Handler.handleCallback(Handler.java:751)
        at android.os.Handler.dispatchMessage(Handler.java:95)
        at android.os.Looper.loop(Looper.java:154)
        at android.app.ActivityThread.main(ActivityThread.java:6119)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:886)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:776)
```